### PR TITLE
Redesenha tela de detalhes (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 ## User settings
 xcuserdata/
 
+## macOS files
+*.DS_Store
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout

--- a/DateCounter.xcodeproj/project.pbxproj
+++ b/DateCounter.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		4369B8D628ECB1E1007B7935 /* DateCounterUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369B8D528ECB1E1007B7935 /* DateCounterUITestsLaunchTests.swift */; };
 		43A06AF32920752C0003EB5B /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369B8B428ECB1E0007B7935 /* Persistence.swift */; };
 		43A06AF4292075300003EB5B /* DateCounter.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4369B8B628ECB1E0007B7935 /* DateCounter.xcdatamodeld */; };
+		43C2C79E2932E4DC00F08C36 /* LunarEclipses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2C79D2932E4DC00F08C36 /* LunarEclipses.swift */; };
+		43C2C7A029339DA700F08C36 /* DefaultDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2C79F29339DA700F08C36 /* DefaultDetailView.swift */; };
 		43F0D2232904ACE6004C1D8E /* EventListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F0D2222904ACE6004C1D8E /* EventListRow.swift */; };
 		43F0D2252904CB73004C1D8E /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F0D2242904CB73004C1D8E /* Preferences.swift */; };
 		BF1E20A928F5968A00D688B0 /* FilteredList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E20A828F5968A00D688B0 /* FilteredList.swift */; };
@@ -138,6 +140,8 @@
 		4369B8CF28ECB1E1007B7935 /* DateCounterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DateCounterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4369B8D328ECB1E1007B7935 /* DateCounterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCounterUITests.swift; sourceTree = "<group>"; };
 		4369B8D528ECB1E1007B7935 /* DateCounterUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCounterUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		43C2C79D2932E4DC00F08C36 /* LunarEclipses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarEclipses.swift; sourceTree = "<group>"; };
+		43C2C79F29339DA700F08C36 /* DefaultDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDetailView.swift; sourceTree = "<group>"; };
 		43F0D2222904ACE6004C1D8E /* EventListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventListRow.swift; sourceTree = "<group>"; };
 		43F0D2242904CB73004C1D8E /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		BF03C3D0292BDA3700D21849 /* PRIVACY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PRIVACY.md; sourceTree = "<group>"; };
@@ -321,6 +325,7 @@
 				BF1E20A828F5968A00D688B0 /* FilteredList.swift */,
 				43F0D2222904ACE6004C1D8E /* EventListRow.swift */,
 				43F0D2242904CB73004C1D8E /* Preferences.swift */,
+				43C2C79F29339DA700F08C36 /* DefaultDetailView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -330,6 +335,7 @@
 			children = (
 				BF7821CB290174A600838000 /* DateCounterCommands.swift */,
 				4369B8B428ECB1E0007B7935 /* Persistence.swift */,
+				43C2C79D2932E4DC00F08C36 /* LunarEclipses.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -593,9 +599,11 @@
 				435D4790291B1EBB006714A3 /* Widgets.intentdefinition in Sources */,
 				43F0D2232904ACE6004C1D8E /* EventListRow.swift in Sources */,
 				4369B8B528ECB1E0007B7935 /* Persistence.swift in Sources */,
+				43C2C7A029339DA700F08C36 /* DefaultDetailView.swift in Sources */,
 				43F0D2252904CB73004C1D8E /* Preferences.swift in Sources */,
 				4369B8BA28ECB1E0007B7935 /* ContentView.swift in Sources */,
 				BF7821CC290174A600838000 /* DateCounterCommands.swift in Sources */,
+				43C2C79E2932E4DC00F08C36 /* LunarEclipses.swift in Sources */,
 				BFEE1CD828EF6BF4004E52D8 /* DetailView.swift in Sources */,
 				4369B8B828ECB1E0007B7935 /* DateCounter.xcdatamodeld in Sources */,
 				BF1E20A928F5968A00D688B0 /* FilteredList.swift in Sources */,
@@ -683,7 +691,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -713,7 +720,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -742,7 +748,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.EventIntentsUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -770,7 +775,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.EventIntentsUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -799,7 +803,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.EventIntents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -827,7 +830,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter.EventIntents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -892,6 +894,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -947,6 +950,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -986,7 +990,6 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1029,7 +1032,6 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1050,7 +1052,6 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = RGUPB9UU3P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1072,7 +1073,6 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = RGUPB9UU3P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1093,7 +1093,6 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = RGUPB9UU3P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1115,7 +1114,6 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = RGUPB9UU3P;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.com.angelicameira.DateCounterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/DateCounter/Resources/LunarEclipses.swift
+++ b/DateCounter/Resources/LunarEclipses.swift
@@ -1,0 +1,31 @@
+//
+//  LunarEclipses.swift
+//  TheDateCounter
+//
+//  Created by Angélica Andrade de Meira on 26/11/22.
+//
+
+import Foundation
+
+struct LunarEclipse {
+    enum EclipseType: String {
+        case partial = "Partial"
+        case total = "Total"
+        case penumbral = "Penumbral"
+        
+        var stringValue: String { rawValue }
+    }
+    
+    let date: Date?
+    let visibility: String
+    let type: EclipseType
+}
+
+let lunarEclipseDates: [LunarEclipse] = [
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2023, month: 5, day: 5, hour: 17, minute: 24).date, visibility: "Africa, Asia, Australia", type: .penumbral),
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2023, month: 10, day: 28, hour: 20, minute: 15).date, visibility: "East Americas, Europe, Africa, Asia, Australia", type: .partial),
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2024, month: 3, day: 25, hour: 7, minute: 13).date, visibility: "Americas", type: .penumbral),
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2024, month: 9, day: 18, hour: 2, minute: 45).date, visibility: "Americas, Europe, Africa", type: .partial),
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2025, month: 3, day: 14, hour: 20, minute: 15).date, visibility: "Pacific, Americas, Western Europe, Western Africa", type: .total),
+    LunarEclipse(date: DateComponents(calendar: Calendar(identifier: .gregorian), year: 2025, month: 9, day: 7, hour: 18, minute: 12).date, visibility: "Europe, Africa, Asia, Australia", type: .total),
+]

--- a/DateCounter/Views/ContentView.swift
+++ b/DateCounter/Views/ContentView.swift
@@ -8,7 +8,18 @@
 import SwiftUI
 import CoreData
 
+#if !os(OSX)
+extension UISplitViewController {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        self.preferredDisplayMode = .oneBesideSecondary
+        self.preferredSplitBehavior = .displace
+    }
+}
+#endif
+
 struct ContentView: View {
+    @Environment(\.managedObjectContext) private var viewContext
     @State private var showManageEventView = false
     @State private var showError = false
     @State private var errorMessage = "No error"
@@ -44,14 +55,14 @@ struct ContentView: View {
                         }
                     }
                 }
-            defaultDetailView
+            DefaultDetailView(showError: $showError, errorMessage: $errorMessage)
         }
         
         .sheet(isPresented: $showManageEventView) {
             ManageEventView()
         }
         
-        .alert("An error occurred when deleting event", isPresented: $showError, actions: {
+        .alert("An error occurred when deleting an event", isPresented: $showError, actions: {
             Text("Ok")
         }, message: {
             Text(errorMessage)
@@ -120,14 +131,10 @@ struct ContentView: View {
         }
     }
     
-#if os(OSX)
     func toggleSidebar() {
+#if os(OSX)
         NSApp.sendAction(#selector(NSSplitViewController.toggleSidebar(_:)), to: nil, from: nil)
-    }
 #endif
-    
-    private var defaultDetailView: some View {
-        Text("Select an event")
     }
     
     func monthForFuture(period: Period) -> Date {
@@ -161,6 +168,10 @@ enum Period: String, CaseIterable, Codable {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+            .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
+            .previewDisplayName("No events (new user)")
+        ContentView()
             .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+            .previewDisplayName("Some events (existing user)")
     }
 }

--- a/DateCounter/Views/DefaultDetailView.swift
+++ b/DateCounter/Views/DefaultDetailView.swift
@@ -1,0 +1,157 @@
+//
+//  Default.swift
+//  TheDateCounter
+//
+//  Created by Angélica Andrade de Meira on 27/11/22.
+//
+
+import Foundation
+import SwiftUI
+import CoreData
+
+struct DefaultDetailView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @State var showManageEventView: Bool = false
+    @Binding var showError: Bool
+    @Binding var errorMessage: String
+    @State private var updateMessage = false
+    var eventCount: Int {
+        let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
+        do {
+            return try viewContext.count(for: fetchRequest)
+        } catch {
+#if DEBUG
+            print(error)
+#endif
+            return 0
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            if updateMessage || true {
+                Text("Welcome!")
+                    .font(.largeTitle)
+                    .foregroundColor(.orange)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+                
+                if eventCount == 0 {
+                    noEventsMessageView
+                } else {
+                    pickEventMessageView
+                }
+            }
+        }
+        .padding()
+        
+        .sheet(isPresented: $showManageEventView) {
+            ManageEventView()
+        }
+    }
+    
+    @ViewBuilder
+    var noEventsMessageView: some View {
+        VStack {
+            HStack {
+#if os(OSX) || os(tvOS)
+                Text("Start by clicking")
+#else
+                Text("Start by tapping")
+#endif
+                Button {
+                    showManageEventView = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                Text("to create a new event")
+            }
+            .padding(.bottom)
+            VStack {
+                Text("Want some ideas?")
+                Button {
+                    showManageEventView = false
+                    addSampleEvents()
+                } label: {
+                    Text("Add some sample events for me")
+                }
+            }
+        }
+    }
+    
+    var pickEventMessageView: some View {
+        VStack {
+#if os(OSX) || os(tvOS)
+            Text("Click an event to see details")
+#else
+            Text("Tap an event to see details")
+#endif
+        }
+    }
+    
+    private func addSampleEvents() {
+        let gregorianCalendar = Calendar(identifier: .gregorian)
+        
+        updateMessage.toggle()
+        
+        for lunarEclipseDate in lunarEclipseDates {
+            if let date = lunarEclipseDate.date,
+               date.compare(Date.now) == .orderedDescending {
+                let lunarEclipseEvent = Event(context: viewContext)
+                lunarEclipseEvent.title = "\(lunarEclipseDate.type.stringValue) lunar eclipse"
+                lunarEclipseEvent.eventDescription = "Will be visible from \(lunarEclipseDate.visibility).\nThe hour corresponds to the Terrestrial Dynamical Time of greatest eclipse"
+                lunarEclipseEvent.date = lunarEclipseDate.date
+                break
+            }
+        }
+        
+        let friendsBirthdayEvent = Event(context: viewContext)
+        friendsBirthdayEvent.title = "Close friend's birthday"
+        friendsBirthdayEvent.eventDescription = "Edit this event to set the birthday of a person dear to you"
+        friendsBirthdayEvent.date = Calendar.current.date(byAdding: DateComponents(month: 2, day: 5), to: Date.now)
+        
+        let iceAgeEvent = Event(context: viewContext)
+        iceAgeEvent.title = "Next ice age"
+        iceAgeEvent.eventDescription = "The amount of anthropogenic greenhouse gases emitted into Earth's oceans and atmosphere is predicted to prevent the next glacial period for the next 500,000 years, which otherwise would begin in around 50,000 years, and likely more glacial cycles after."
+        iceAgeEvent.date = gregorianCalendar
+            .date(from:
+                    DateComponents(
+                        year: 502_022, month: 1, day: 1,
+                        hour: 0, minute: 0
+                    )
+            )
+        
+        var date: Date = Date.now,
+            intervalToWeekend: TimeInterval = 0
+        if gregorianCalendar.nextWeekend(startingAfter: Date.now, start: &date, interval: &intervalToWeekend) {
+            let nextWeekendEvent = Event(context: viewContext)
+            nextWeekendEvent.title = "Time until next weekend"
+            nextWeekendEvent.eventDescription = "Any exciting plans for the weekend? Edit this event and write them down!"
+            nextWeekendEvent.date = date
+        }
+        
+        let graduationEvent = Event(context: viewContext)
+        graduationEvent.title = "College graduation date"
+        graduationEvent.eventDescription = "If you started college today, you would graduate after about 4 years on average"
+        graduationEvent.date = gregorianCalendar.date(byAdding: DateComponents(year: 4), to: Date.now)
+        
+        do {
+            try viewContext.save()
+        } catch {
+            viewContext.rollback()
+            errorMessage = error.localizedDescription
+            showError = true
+        }
+    }
+}
+
+struct DefaultDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        DefaultDetailView(showError: .constant(false), errorMessage: .constant("No error message"))
+            .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
+            .previewDisplayName("No events (new user)")
+        DefaultDetailView(showError: .constant(false), errorMessage: .constant("No error message"))
+            .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+            .previewDisplayName("Some events (existing user)")
+    }
+}

--- a/DateCounter/Views/DetailView.swift
+++ b/DateCounter/Views/DetailView.swift
@@ -23,13 +23,9 @@ struct DetailView: View {
         return !(event.isDeleted || event.title == nil)
     }
     
-    var defaultDetailView: some View {
-        Text("Select an event")
-    }
-    
     var body: some View {
         if !isValidEvent {
-            defaultDetailView
+            DefaultDetailView(showError: $showError, errorMessage: $errorMessage)
         } else {
             Group {
                 displayingView

--- a/DateCounter/Views/ManageEventView.swift
+++ b/DateCounter/Views/ManageEventView.swift
@@ -39,16 +39,33 @@ struct ManageEventView: View {
                 .padding(.top)
 #endif
             Form {
+#if os(OSX)
                 Section {
                     TextField("Event name", text: $title)
                 }
                 Section {
                     TextField("Description", text: $eventDescription)
                 }
+#else
+                Section {
+                    TextEditor(text: $title)
+                } header: {
+                    Text("Title")
+                }
+                Section {
+                    TextEditor(text: $eventDescription)
+                } header: {
+                    Text("Description")
+                }
+#endif
                 Section {
                     DatePicker("Date", selection: $date)
 #if !os(OSX)
                         .datePickerStyle(.graphical)
+#endif
+                } header: {
+#if !os(OSX)
+                    Text("Date")
 #endif
                 }
                 .onAppear(perform: {

--- a/DateCounterUITests/DateCounterUITests.swift
+++ b/DateCounterUITests/DateCounterUITests.swift
@@ -36,7 +36,7 @@ final class DateCounterUITests: XCTestCase {
         let eventsNavigationBar = app.navigationBars["Events"]
         eventsNavigationBar.buttons["Add Event"].tap()
 
-        let eventNameTextField = app/*@START_MENU_TOKEN@*/.textFields["Event name"]/*[[".cells[\"Event name\"].textFields[\"Event name\"]",".textFields[\"Event name\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        let eventNameTextField = app.textViews.firstMatch
         eventNameTextField.tap()
         
         eventNameTextField.typeText("Test")
@@ -53,9 +53,12 @@ final class DateCounterUITests: XCTestCase {
         
         let testNavigationBar = app.navigationBars["Test"]
         testNavigationBar.buttons["Edit this event"].tap()
-        let eventTitleTextField = app/*@START_MENU_TOKEN@*/.textFields["Event name"]/*[[".cells.textFields[\"Event name\"]",".textFields[\"Event name\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        let eventTitleTextField = app.textViews.firstMatch
+        
         eventTitleTextField.tap()
+        continueAfterFailure = true
         eventTitleTextField.clearText()
+        continueAfterFailure = false
 
         let editEventNavigationBar = app.navigationBars["Edit event"]
         editEventNavigationBar.buttons["Save"].tap()
@@ -105,6 +108,10 @@ extension XCUIElement {
             return
         }
         self.tap()
+        let app = XCUIApplication()
+        app/*@START_MENU_TOKEN@*/.staticTexts["Select All"]/*[[".menuItems[\"Select All\"].staticTexts[\"Select All\"]",".staticTexts[\"Select All\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app/*@START_MENU_TOKEN@*/.staticTexts["Cut"]/*[[".menuItems[\"Cut\"].staticTexts[\"Cut\"]",".staticTexts[\"Cut\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        
         let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
         self.typeText(deleteString)
     }


### PR DESCRIPTION
Closes #70 

* Começa a fazer a feature 44

* Termina modificações solicitadas na tela de detalhes

* Increments app version for next release

* Improves event management design and allows multiline text

* Adds preview events and redesigns welcome message

* Refactors DefaultDetailView to its own struct

* Fixes iOS build, unit tests

* Deletes unused icon, adds Xcode preview

* Deletes .DS_Store file

* Adds .DS_Store to ignored files

* Fixes tests on iOS 15

* Fixes code review notes

Co-authored-by: Antonio Germano <816290+antoniogermano@users.noreply.github.com>